### PR TITLE
Drag with move

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ spec/reports
 test/tmp
 test/version_tmp
 tmp
+.vs/

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,4 +1,8 @@
-===	Version 0.6	/ 2014-11014
+===	Version 0.7	/ 2019-01-22
+*	Changes
+		*	Drag events now send an intermediate MouseMove event
+
+===	Version 0.6	/ 2014-11-14
 *	Changes
 		*	Loosened the ffi dependency to ~> 1.9.4
 

--- a/ext/UiaDll/UIA.Helper/Mouse.cs
+++ b/ext/UiaDll/UIA.Helper/Mouse.cs
@@ -11,13 +11,7 @@ namespace UIA.Helper
         [DllImport("user32.dll")]
         static extern void mouse_event(uint flags, uint x, uint y, uint data, int extraInfo);
 
-        [Flags]
-        public enum MouseEvent
-        {
-            Leftdown = 0x00000002,
-            Leftup = 0x00000004,
-        }
-
+        private const uint MOUSEEVENTLF_MOVE = 0x1;
         private const uint MOUSEEVENTLF_LEFTDOWN = 0x2;
         private const uint MOUSEEVENTLF_LEFTUP = 0x4;
 
@@ -25,6 +19,9 @@ namespace UIA.Helper
         {
             Cursor.Position = new System.Drawing.Point(startX, startY);
             Down();
+
+            Move((uint)((startX + endX) / 2), (uint)((startY + endY) / 2));
+
             Cursor.Position = new System.Drawing.Point(endX, endY);
             Up();
         }
@@ -46,7 +43,7 @@ namespace UIA.Helper
 
             var point = GetPoint();
 
-            Cursor.Position = new System.Drawing.Point((int) point.X, (int) point.Y);
+            Cursor.Position = new System.Drawing.Point((int)point.X, (int)point.Y);
             Down();
             Up();
         }
@@ -59,6 +56,11 @@ namespace UIA.Helper
         private static void Down()
         {
             mouse_event(MOUSEEVENTLF_LEFTDOWN, 0, 0, 0, 0);
+        }
+
+        private static void Move(uint x, uint y)
+        {
+            mouse_event(MOUSEEVENTLF_MOVE, x, y, 0, 0);
         }
 
         private static Point Center(AutomationElement element)

--- a/lib/uia/version.rb
+++ b/lib/uia/version.rb
@@ -1,3 +1,3 @@
 module Uia
-  VERSION = '0.6'
+  VERSION = '0.7'
 end

--- a/spec/uia/element_spec.rb
+++ b/spec/uia/element_spec.rb
@@ -61,22 +61,22 @@ describe Uia::Element do
       Then { element.control_type == :window }
 
       context 'unknown' do
-        Given { raw_element.stub(:control_type_id).and_return(777) }
+        Given { allow(raw_element).to receive(:control_type_id).and_return(777) }
         Then { element.control_type == :unknown }
       end
     end
 
     context '#patterns' do
-      Then { element.patterns.should =~ [:transform, :window] }
+      Then { expect(element.patterns).to match_array([:transform, :window]) }
 
       context 'unknown' do
-        Given { raw_element.stub(:pattern_ids).and_return([7777]) }
-        Then { element.patterns.should == [:unknown] }
+        Given { allow(raw_element).to receive(:pattern_ids).and_return([7777]) }
+        Then { expect(element.patterns).to eq([:unknown]) }
       end
 
       context '#as' do
         When(:cast) { element.as :toggle }
-        Then { cast.should have_failed UnsupportedPattern, "Pattern toggle not found in [:window, :transform]" }
+        Then { expect(cast).to have_failed UnsupportedPattern, "Pattern toggle not found in [:window, :transform]" }
       end
     end
 
@@ -141,7 +141,7 @@ describe Uia::Element do
 
     context 'invalid' do
       When(:bad_locator) { element.find(bad_locator: 123) }
-      Then { bad_locator.should have_failed BadLocator, "{:bad_locator=>123} is not a valid locator" }
+      Then { expect(bad_locator).to have_failed BadLocator, "{:bad_locator=>123} is not a valid locator" }
     end
 
     context 'limiting scope' do

--- a/spec/uia/keys_spec.rb
+++ b/spec/uia/keys_spec.rb
@@ -25,6 +25,6 @@ describe Uia::Keys do
 
   context 'invalid' do
     When(:bad_keys) { encode('something', :bad_key) }
-    Then { bad_keys.should have_failed InvalidKey, "#{:bad_key} is not a valid key" }
+    Then { expect(bad_keys).to have_failed InvalidKey, "#{:bad_key} is not a valid key" }
   end
 end

--- a/spec/uia_spec.rb
+++ b/spec/uia_spec.rb
@@ -37,7 +37,7 @@ describe Uia do
 
     context 'by window handle' do
       Then { expect(Uia.find_element(handle: main_window.handle)).to be_instance_of(Element) }
-      Then { expect { Uia.find_element(handle: 0x0) }.to raise_error }
+      Then { expect { Uia.find_element(handle: 0x0) }.to raise_error(RuntimeError, /hwnd cannot be IntPtr.Zero or null/) }
     end
 
     context 'by title' do

--- a/spec/uia_spec.rb
+++ b/spec/uia_spec.rb
@@ -31,7 +31,7 @@ describe Uia do
 
       context 'can search descendants' do
         Given(:element_with_no_handle) { Uia.find_element(id: 'MainFormWindow').find(name: 'Parent Two') }
-        Then { element_with_no_handle.click.should be_true }
+        Then { element_with_no_handle.click.should be true }
       end
     end
 

--- a/spec/uia_spec.rb
+++ b/spec/uia_spec.rb
@@ -31,7 +31,7 @@ describe Uia do
 
       context 'can search descendants' do
         Given(:element_with_no_handle) { Uia.find_element(id: 'MainFormWindow').find(name: 'Parent Two') }
-        Then { element_with_no_handle.click.should be true }
+        Then { expect(element_with_no_handle.click).to be true }
       end
     end
 
@@ -48,7 +48,7 @@ describe Uia do
 
     context 'invalid locators' do
       When(:bad_input) { Uia.find_element(bad: 123) }
-      Then { bad_input.should have_failed(Uia::BadLocator, '{:bad=>123} is not a valid locator') }
+      Then { expect(bad_input).to have_failed(Uia::BadLocator, '{:bad=>123} is not a valid locator') }
     end
   end
 end

--- a/uia.gemspec
+++ b/uia.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'ffi', '~> 1.9.4'
   spec.add_runtime_dependency 'require_all'
 
-  spec.add_development_dependency 'bundler', '~> 1.3'
+  spec.add_development_dependency 'bundler', '>= 1.3'
   spec.add_development_dependency 'rake'
   spec.add_development_dependency 'rspec', '~> 2.9'
   spec.add_development_dependency 'rspec-given'

--- a/uia.gemspec
+++ b/uia.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_runtime_dependency 'ffi', '~> 1.11.2'
-  spec.add_runtime_dependency 'require_all', '3.0'
+  spec.add_runtime_dependency 'require_all', '~> 3.0'
 
   spec.add_development_dependency 'bundler', '>= 1.3'
   spec.add_development_dependency 'rake', '~> 10.5'

--- a/uia.gemspec
+++ b/uia.gemspec
@@ -25,13 +25,13 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 
-  spec.add_runtime_dependency 'ffi', '~> 1.9.4'
-  spec.add_runtime_dependency 'require_all'
+  spec.add_runtime_dependency 'ffi', '~> 1.11.2'
+  spec.add_runtime_dependency 'require_all', '3.0'
 
   spec.add_development_dependency 'bundler', '>= 1.3'
-  spec.add_development_dependency 'rake'
-  spec.add_development_dependency 'rspec', '~> 2.9'
-  spec.add_development_dependency 'rspec-given'
-  spec.add_development_dependency 'childprocess'
-  spec.add_development_dependency 'albacore', '~> 2.2'
+  spec.add_development_dependency 'rake', '~> 10.5'
+  spec.add_development_dependency 'rspec', '~> 3.9'
+  spec.add_development_dependency 'rspec-given', '~> 3.8'
+  spec.add_development_dependency 'childprocess', '~> 3.0'
+  spec.add_development_dependency 'albacore', '~> 3.0.1'
 end


### PR DESCRIPTION
Drag operations were not working on Win10 without a MouseMove event. This PR addresses that issue.

Additionally, I bumped the dependencies to their latest possible versions and specified versions for dependencies that previously had none. This required updates to the rspec syntax now that `should` is being removed. I used [transpec](https://github.com/yujinakayama/transpec) to convert to the new `expect` syntax.